### PR TITLE
Shakedown updates, signal fixes, and patrol reminders

### DIFF
--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3259,6 +3259,7 @@
 #include "nsv13\code\game\gamemodes\bloodling.dm"
 #include "nsv13\code\game\gamemodes\overmap\patrol.dm"
 #include "nsv13\code\game\gamemodes\overmap\shakedown.dm"
+#include "nsv13\code\game\gamemodes\overmap\objectives\apnw_efficiency.dm"
 #include "nsv13\code\game\gamemodes\overmap\objectives\destroy_fleet.dm"
 #include "nsv13\code\game\gamemodes\overmap\objectives\go_to_system.dm"
 #include "nsv13\code\game\gamemodes\overmap\objectives\perform_jumps.dm"

--- a/nsv13/code/controllers/subsystem/overmap_mode.dm
+++ b/nsv13/code/controllers/subsystem/overmap_mode.dm
@@ -297,7 +297,7 @@ SUBSYSTEM_DEF(overmap_mode)
 /datum/overmap_gamemode/proc/consequence_five()
 	//Hotdrop O'Clock
 	var/datum/star_system/target = SSstar_system.find_main_overmap().current_system
-	priority_announce("Faction Hunter something something Hotdrop") //need a faction message
+	priority_announce("Attention all ships throughout the fleet, assume DEFCON 1. A Syndicate invasion force has been spotted in [target]. All fleets must return to allied space and assist in the defense.") //need a faction message
 	var/datum/fleet/F = new /datum/fleet/interdiction() //need a fleet
 	target.fleets += F
 	F.current_system = target

--- a/nsv13/code/game/gamemodes/overmap/objectives/apnw_efficiency.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/apnw_efficiency.dm
@@ -1,0 +1,32 @@
+/datum/overmap_objective/apnw_efficiency
+	name = "Test APNW"
+	desc = "Get APNW to target efficiency level"
+	brief = "Test the APNW by raising the repair efficiency to at least target_efficiency %"
+	var/obj/machinery/armour_plating_nanorepair_well/APNW = null
+	var/target_efficiency = 0.50 // out of 1
+
+/datum/overmap_objective/apnw_efficiency/New()
+	. = ..()
+	APNW = locate() in GLOB.machines
+	if(!APNW)
+		message_admins("Overmap gamemode failed to locate APNW! Setting to auto-complete.")
+		status = 1
+	else
+		target_efficiency = rand(40, 80) / 100
+		START_PROCESSING(SSprocessing, src)
+
+/datum/overmap_objective/apnw_efficiency/instance()
+	. = ..()
+	brief = "Test the APNW by raising the repair efficiency to at least [target_efficiency * 100]%"
+
+/datum/overmap_objective/apnw_efficiency/process()
+	check_completion()
+
+/datum/overmap_objective/apnw_efficiency/check_completion()
+	if(status != 0)
+		STOP_PROCESSING(SSprocessing, src)
+		return
+	if(APNW.repair_efficiency >= target_efficiency)
+		SSovermap_mode.update_reminder(objective=TRUE)
+		status = 1
+		STOP_PROCESSING(SSprocessing, src)

--- a/nsv13/code/game/gamemodes/overmap/objectives/destroy_fleet.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/destroy_fleet.dm
@@ -20,6 +20,7 @@
 
 /datum/overmap_objective/destroy_fleets/proc/register_kill()
 	fleets_defeated ++
+	SSovermap_mode.update_reminder(objective=TRUE)
 	check_completion()
 
 /datum/overmap_objective/destroy_fleets/check_completion()

--- a/nsv13/code/game/gamemodes/overmap/objectives/go_to_system.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/go_to_system.dm
@@ -14,4 +14,6 @@
 
 /datum/overmap_objective/go_to_system/check_completion()
 	if(SSstar_system.find_system(SSstar_system.main_overmap) == target_system)
+		SSovermap_mode.update_reminder(objective=TRUE)
 		status = 1
+		UnregisterSignal(SSstar_system.find_main_overmap(), COMSIG_SHIP_ARRIVED)

--- a/nsv13/code/game/gamemodes/overmap/objectives/perform_jumps.dm
+++ b/nsv13/code/game/gamemodes/overmap/objectives/perform_jumps.dm
@@ -16,6 +16,7 @@
 
 /datum/overmap_objective/perform_jumps/proc/register_jump()
 	jumps_completed ++
+	SSovermap_mode.update_reminder(objective=TRUE)
 	check_completion()
 
 /datum/overmap_objective/perform_jumps/check_completion()
@@ -24,3 +25,4 @@
 		return
 	if(jumps_completed >= jumps_required)
 		status = 1
+		UnregisterSignal(SSstar_system.find_main_overmap(), COMSIG_SHIP_ARRIVED)

--- a/nsv13/code/game/gamemodes/overmap/patrol.dm
+++ b/nsv13/code/game/gamemodes/overmap/patrol.dm
@@ -12,3 +12,9 @@
 	selection_weight = 5
 	required_players = 0
 	objectives = list(/datum/overmap_objective/tickets/nt)
+
+	reminder_one = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, please continue on your patrol."
+	reminder_two = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, we are not paying you to idle in space during your assignment."
+	reminder_three = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, your inactivity has been noted and will not be tolerated."
+	reminder_four = "This is Centcomm to the explore vessel currently assigned to the Delphic Expanse, you are expected to fulfill your assigned patrol."
+	reminder_five = "The vessel is no longer responding to commands. Enacting emergency defense conditions. All shipside squads must assist in getting the ship ready for combat by any means necessary."

--- a/nsv13/code/game/gamemodes/overmap/shakedown.dm
+++ b/nsv13/code/game/gamemodes/overmap/shakedown.dm
@@ -5,7 +5,7 @@
 	starting_system = "Argo"
 	starting_faction = "nanotrasen"
 
-	objective_reminder_setting = 3 //Reminder override until we can also do it for jumps
+	objective_reminder_setting = 2 // Combat will delay but not fully reset if it's not the objective
 	reminder_one = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, please continue on your shakedown."
 	reminder_two = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, we are not paying you to idle in space during your assignment."
 	reminder_three = "This is Centcomm to all vessels assigned to explore the Delphic Expanse, your inactivity has been noted and will not be tolerated."
@@ -14,4 +14,4 @@
 
 	selection_weight = 5
 	required_players = 0
-	objectives = list(/datum/overmap_objective/perform_jumps, /datum/overmap_objective/destroy_fleets)
+	objectives = list(/datum/overmap_objective/perform_jumps, /datum/overmap_objective/destroy_fleets, /datum/overmap_objective/apnw_efficiency)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Updates patrol mode reminder text to what it used to be
- Unregisters some signals after objectives are completed
- Adds a shakedown objective to test the APNW
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
add: Test APNW shakedown objective
add: Patrol gamemode reminder text
tweak: Combat delays shakedown reminders, and objective progress resets them
code: Unregisters on-arrival signals once they're not needed anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
